### PR TITLE
Exception added for Single.php

### DIFF
--- a/4. Customizing Theme PHP Files/4.4 Add Excerpt Support and Styled "Continue Reading" Button/content.php
+++ b/4. Customizing Theme PHP Files/4.4 Add Excerpt Support and Styled "Continue Reading" Button/content.php
@@ -23,7 +23,7 @@
 
 	<div class="entry-content">
 		<?php
-			if ( $post->post_excerpt ) {
+			if ( $post->post_excerpt && !is_single()) {  //this prevents the Excerpt appearing in single.php (^-^)v
 				the_excerpt();
 				echo sprintf( '<div class="continue_btn"><a href="%s" class="more-link" rel="bookmark">Continue Reading'.the_title( '<span class="screen-reader-text">"', '"</span>', false ).'</a></div>', esc_url(get_permalink()) );
 			} else {


### PR DESCRIPTION
Added a bit of logic to prevent the Excerpt carrying over to single.php.  Previously, when you click 'continue reading' and are taken to a post single.php, the post remains collapsed in Excerpt form.